### PR TITLE
fix typo

### DIFF
--- a/lessons/assembly-script/setup.md
+++ b/lessons/assembly-script/setup.md
@@ -23,7 +23,7 @@ $ nvm install --lts
 
 Install npx
 ```bash
-$ npm -i -g npx
+$ npm i -g npx
 ```
 
 Create working directory


### PR DESCRIPTION
`npm i -g npx` instead of `npm -i -g npx`

fix #4 