### PR TITLE
Updated web assembly studio links

### DIFF
--- a/lessons/wasm/wasm-intro-contd.md
+++ b/lessons/wasm/wasm-intro-contd.md
@@ -14,7 +14,7 @@ The fundamental unit of code is a module. Within the module, we create functions
 > A Web Assembly module is a tree-based structure known as an [S-expression](https://developer.mozilla.org/en-US/docs/WebAssembly/Understanding_the_text_format#s-expressions). Just thought you'd like to know.
 
 #### Web Assembly Studio
-We're going use [Web Assembly Studio](https://webassembly.studio/) to write our first [hello world](https://webassembly.studio/?f=a8z71cwsulu).
+We're going use [Web Assembly Studio](https://wasm-studio.surge.sh/) to write our first hello world.
 
 Our function will take a 32-bit integer as input and return the input unmodified.
 ```wasm


### PR DESCRIPTION
Web Assembly Studio is down (there's even a popup at the frontendmasters course), but I was following the links in the presentation and got little confused. Apparently there's no way to save a project to let the others fork it. Create gist also doesn't work on this forked deployment so it's a best-effort

<img width="446" alt="image" src="https://user-images.githubusercontent.com/1552189/184428214-3dbf8228-1081-4006-820d-f9bd4f175809.png">

Awesome course btw